### PR TITLE
Potential fix for code scanning alert no. 9: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/OAP/security/code-scanning/9](https://github.com/CreoDAMO/OAP/security/code-scanning/9)

To address the missing rate limiting for the `/api/admin/agent/execute` POST route in `server/routes.ts`, a rate-limiting middleware should be added. The best approach is to use an existing Express-compatible rate limiting package, such as `express-rate-limit`, and apply a suitable limiter directly to the `/api/admin/agent/execute` route. This requires importing the package, configuring a rate limiter instance with strict limits suitable for admin actions (e.g., allowing only a few requests per minute), and attaching it before the route's async handler in the registration function. Additional middleware or package initialization should be minimal and limited to what is required for this route only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
