### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -507,7 +507,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Admin Panel Routes (Protected)
-  app.get("/api/admin/overview", async (req, res) => {
+  app.get("/api/admin/overview", adminAgentLimiter, async (req, res) => {
     try {
       const token = req.headers.authorization?.replace('Bearer ', '');
       const decoded = jwt.verify(token, JWT_SECRET) as any;
@@ -524,7 +524,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.get("/api/admin/finances", async (req, res) => {
+  app.get("/api/admin/finances", adminAgentLimiter, async (req, res) => {
     try {
       const token = req.headers.authorization?.replace('Bearer ', '');
       const decoded = jwt.verify(token, JWT_SECRET) as any;


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/OAP/security/code-scanning/4](https://github.com/CreoDAMO/OAP/security/code-scanning/4)

To fix the missing rate limiting on the `/api/admin/overview` route handler, we should apply a rate limiting middleware to this endpoint. Since there's already a strict limiter defined (`adminAgentLimiter`) at lines 12–30 for admin-related actions, we should reuse this middleware for all sensitive admin routes, including `/api/admin/overview` and `/api/admin/finances`. The change should occur within `server/routes.ts`, specifically by attaching `adminAgentLimiter` as middleware in the route definitions for these endpoints. The fix requires updating these route handlers by adding `adminAgentLimiter` as the first argument in the route definition calls, i.e., `app.get("/api/admin/overview", adminAgentLimiter, async (req, res) => {...})`.

No additional imports or method definitions are needed, since the necessary limiter middleware is already defined.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
