### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express";
+import rateLimit from "express-rate-limit";
 import fs from "fs";
 import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
@@ -41,6 +42,16 @@ export async function setupVite(app: Express, server: Server) {
   });
 
   app.use(vite.middlewares);
+
+  // rate limit expensive wildcard handler to prevent DoS
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+  });
+  app.use("*", limiter);
+
   app.use("*", async (req, res, next) => {
     const url = req.originalUrl;
 


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/OAP/security/code-scanning/1](https://github.com/CreoDAMO/OAP/security/code-scanning/1)

To fix the lack of rate limiting, apply an established Express rate-limiting middleware such as `express-rate-limit` around the handler in question. The `express-rate-limit` package is widely used and can be configured to allow a reasonable number of requests per time window (e.g., 100 requests per 15 minutes), which protects against basic DoS attacks without significantly impacting normal usage patterns.

Implementation steps:
- Import `express-rate-limit` at the top of the file.
- Create a limiter instance with your desired configuration (e.g., 100 requests per 15 minutes).
- Apply the limiter middleware *before* the expensive route handler (`app.use("*", ...)` in `setupVite`).

All changes are confined to `server/vite.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
