### PR TITLE
Potential fix for code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -588,7 +588,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.post("/api/admin/agent/config", async (req, res) => {
+  app.post("/api/admin/agent/config", adminAgentLimiter, async (req, res) => {
     try {
       const token = req.headers.authorization?.replace('Bearer ', '');
       const decoded = jwt.verify(token, JWT_SECRET) as any;


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/OAP/security/code-scanning/8](https://github.com/CreoDAMO/OAP/security/code-scanning/8)

To fix the issue, we should apply rate-limiting middleware (already set up as `adminAgentLimiter`) to the `/api/admin/agent/config` route handler. This can be done by adding `adminAgentLimiter` as a second argument to the route definition, so the sequence will be:  
`app.post("/api/admin/agent/config", adminAgentLimiter, async (req, res) => { ... })`.  
No new methods or definitions are required, as the limiter is already imported and defined. This change is local to the route definition in `server/routes.ts` and does not affect route functionality outside the rate limit checks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
