### PR TITLE
Potential fix for code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -569,7 +569,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Agent Kit routes
-  app.get("/api/admin/agent/status", async (req, res) => {
+  app.get("/api/admin/agent/status", adminAgentLimiter, async (req, res) => {
     try {
       const token = req.headers.authorization?.replace('Bearer ', '');
       const decoded = jwt.verify(token, JWT_SECRET) as any;


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/OAP/security/code-scanning/7](https://github.com/CreoDAMO/OAP/security/code-scanning/7)

The correct fix is to apply the `adminAgentLimiter` rate limiting middleware to the `/api/admin/agent/status` route, as is already done for other sensitive admin routes in this file (such as `/api/admin/finances` and `/api/admin/agent/config`). This ensures consistent protection for all admin-related endpoints that perform potentially expensive or security-sensitive operations. All that is needed is to insert `adminAgentLimiter` as middleware in the route definition:

- Locate the route definition for `app.get("/api/admin/agent/status", ...)` (line 572).
- Insert `adminAgentLimiter` as the second argument, so the handler becomes the third argument.
- No new imports or logic are required, as `adminAgentLimiter` is already defined.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
