### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -487,7 +487,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   const ADMIN_EMAIL = process.env.ADMIN_EMAIL || 'admin@example.com';
   const jwt = require('jsonwebtoken');
 
-  app.post("/api/admin/login", async (req, res) => {
+  app.post("/api/admin/login", adminAgentLimiter, async (req, res) => {
     try {
       const { email, password } = req.body;
       const { adminSystem } = await import('./admin');


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/OAP/security/code-scanning/3](https://github.com/CreoDAMO/OAP/security/code-scanning/3)

To fix the problem, a rate limiting middleware should be applied to the `/api/admin/login` route. Since `express-rate-limit` is already imported and an `adminAgentLimiter` exists (5 requests per 5 minutes, based on admin email or IP), this limiter can be reused for the login route. No new dependencies are needed. 

**How to apply the fix:**  
- In the `/api/admin/login` route definition (`app.post("/api/admin/login", async (req, res) => ...`), add `adminAgentLimiter` as a middleware before the async handler, just as is done for the protected admin panel GET routes.
- Ensure the import and definition of `adminAgentLimiter` are not altered.
- Do not alter the route logic or parameters.

**Files and regions to change:**  
- Only edit the `/api/admin/login` route definition in `server/routes.ts` (around line 490).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
