### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -541,7 +541,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.post("/api/admin/distribute", async (req, res) => {
+  app.post("/api/admin/distribute", adminAgentLimiter, async (req, res) => {
     try {
       const token = req.headers.authorization?.replace('Bearer ', '');
       const decoded = jwt.verify(token, JWT_SECRET) as any;


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/OAP/security/code-scanning/6](https://github.com/CreoDAMO/OAP/security/code-scanning/6)

To fix the problem, we should apply the same `adminAgentLimiter` middleware to the `/api/admin/distribute` endpoint as is done for other admin endpoints in this file. This can be accomplished by inserting `adminAgentLimiter` as a middleware argument prior to the route handler function for the endpoint. This ensures that requests to the route are limited to the configured threshold, mitigating the risk of denial-of-service or abuse. The change should be made directly to the line defining the route, which is line 544 (`app.post("/api/admin/distribute", async (req, res) => {`) in `server/routes.ts`.

No changes to imports or new middleware setup are necessary—`adminAgentLimiter` is already defined and used elsewhere in this file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
