### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -89,6 +89,15 @@ export function serveStatic(app: Express) {
 
   app.use(express.static(distPath));
 
+  // rate limit expensive wildcard static file fallback 
+  const staticLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+  });
+  app.use("*", staticLimiter);
+
   // fall through to index.html if the file doesn't exist
   app.use("*", (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/OAP/security/code-scanning/2](https://github.com/CreoDAMO/OAP/security/code-scanning/2)

To fix this issue, a rate limiter should be applied to the wildcard static handler in `serveStatic` (lines 93-95). Utilize the already imported `express-rate-limit` package to limit how many times clients can hit the fallback handler per unit time. It is best to instantiate a limiter within `serveStatic` similar to how it's done in `setupVite`, and apply it to the `app.use("*", ...)` route before the handler itself. This change should only affect these lines; the implementation does not need to adjust business logic or routing order, just ensure that the static file fallback is protected by rate limiting.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
